### PR TITLE
correct cz into cs

### DIFF
--- a/index-cz.html
+++ b/index-cz.html
@@ -52,11 +52,11 @@
                       <li class="navbar-list-item"><a href="#contact">Kontakt</a></li>
                   </ul>
                       <div id="langs" class="langs-switcher">
-                              <span data-value="cz" class="navbar-list-item-lang" id="active"><a href="#" class="default-lang"><i class="fa fa-globe" aria-hidden="true"></i>Česky</a></span>
+                              <span data-value="cs" class="navbar-list-item-lang" id="active"><a href="#" class="default-lang"><i class="fa fa-globe" aria-hidden="true"></i>Česky</a></span>
                               <ul id="langs-switcher-options" class="langs-switcher-options hidden">
                                   <li data-value="en" class="navbar-list-item-lang"><a href="index-en.html"><i class="fa fa-globe" aria-hidden="true"></i>English</a></li>
                                   <li data-value="de" class="navbar-list-item-lang"><a href="index-de.html"><i class="fa fa-globe" aria-hidden="true"></i>Deutsch</a></li>
-                                  <li data-value="sk" class="navbar-list-item-lang"><a href="index-sk.html"><i class="fa fa-globe" aria-hidden="true"></i>slovensky</a></li>
+                                  <li data-value="sk" class="navbar-list-item-lang"><a href="index-sk.html"><i class="fa fa-globe" aria-hidden="true"></i>Slovensky</a></li>
                               </ul>
                   </div>
                 </div>

--- a/index-de.html
+++ b/index-de.html
@@ -57,7 +57,7 @@
                                     aria-hidden="true"></i>Deutsch</a>
                         </span>
                         <ul id="langs-switcher-options" class="langs-switcher-options hidden">
-                            <li data-value="cz" class="navbar-list-item-lang"><a href="index-cz.html"><i
+                            <li data-value="cs" class="navbar-list-item-lang"><a href="index-cz.html"><i
                                         class="fa fa-globe" aria-hidden="true"></i>Česky</a>
                             </li>
                             <li data-value="sk" class="navbar-list-item-lang"><a href="index-sk.html"><i

--- a/index-en.html
+++ b/index-en.html
@@ -60,7 +60,7 @@
                             <a href="#" class="default-lang"><i class="fa fa-globe" aria-hidden="true"></i>English</a>
                         </span>
                         <ul id="langs-switcher-options" class="langs-switcher-options hidden">
-                            <li data-value="cz" class="navbar-list-item-lang" id="sk">
+                            <li data-value="cs" class="navbar-list-item-lang" id="cs">
                                 <a href="index-cz.html"><i class="fa fa-globe" aria-hidden="true"></i>Česky</a>
                             </li>
                             <li data-value="sk" class="navbar-list-item-lang" id="sk">
@@ -264,7 +264,7 @@
                 </div>
                 <div class="education">
                     <div class="container column60">
-                        <h3 class="cnt uppercase">education</h3>
+                        <h3 class="cnt uppercase">Education</h3>
                         <ul class="education-list">
                             <li class="btm2">
                                 2014—2019 <span class="bold">PCA Institute,</span> Prague, Psychotherapy training in the

--- a/index-sk.html
+++ b/index-sk.html
@@ -53,7 +53,7 @@
                     <div id="langs" class="langs-switcher">
                             <span data-value="sk" class="navbar-list-item-lang" id="active"><a href="#" class="default-lang"><i class="fa fa-globe" aria-hidden="true"></i>Slovensky</a></span>
                             <ul id="langs-switcher-options" class="langs-switcher-options hidden">
-                                <li data-value="en" class="navbar-list-item-lang"><a href="index-cz.html"><i class="fa fa-globe" aria-hidden="true"></i>Česky</a></li>
+                                <li data-value="cs" class="navbar-list-item-lang"><a href="index-cz.html"><i class="fa fa-globe" aria-hidden="true"></i>Česky</a></li>
                                 <li data-value="de" class="navbar-list-item-lang"><a href="index-de.html"><i class="fa fa-globe" aria-hidden="true"></i>Deutsch</a></li>
                                 <li data-value="en" class="navbar-list-item-lang"><a href="index-en.html"><i class="fa fa-globe" aria-hidden="true"></i>English</a></li>
                             </ul>

--- a/index.php
+++ b/index.php
@@ -1,7 +1,7 @@
 <?php
 
-$supported_langs = array("en", "cz", "sk", "de");
-$default_lang = "cz";
+$supported_langs = array("en", "cs", "sk", "de");
+$default_lang = "cs";
 
 $accept_lang = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
 $lang = substr($accept_lang, 0, 2);


### PR DESCRIPTION
I realised during the most recent validation that the correct code for Czech language is cs, not cz  https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry. This is now changed in all relevant files.