### PR TITLE
improve appearance of button in mobile version

### DIFF
--- a/index-cs.html
+++ b/index-cs.html
@@ -85,7 +85,7 @@
                         Někdy se stává, že sami neumíme vyřešit naše duševní obtíže. Tehdy není ostuda vyhledat pomoc. Ba právě naopak, včasná terapie může ušetřit člověka od zbytečného trápení.
                     </p>
                     <p>
-                        Terapie je cestou práce na sobě a umožňuje změnit sebe i svět - to, jak jej prožíváme. Tím se obnovuje sebedůvěra a radost ze života.
+                        Terapie je cestou práce na sobě a umožňuje změnit sebe i svět—to, jak jej prožíváme. Tím se obnovuje sebedůvěra a radost ze života.
                     </p>
                 </div>
             </div>
@@ -205,7 +205,7 @@
                             A nakonec to byla právě psychoterapie, která mi změnila pohled na život. Uvědomil jsem si při ní, že život je v pořádku, tak jak je. Krása tohoto uvědomění byla, že se jednalo o praktickou zkušenost, tedy zážitek a ne jen slova.
                         </p>
                         <p>
-                            Tehdy jsem našel své nové povolání. Dal jsem se na studium psychologie a na stejný výcvik, ve kterém jsem absolvoval terapii - PCA.
+                            Tehdy jsem našel své nové povolání. Dal jsem se na studium psychologie a na stejný výcvik, ve kterém jsem absolvoval terapii—PCA.
                         </p>
                         <p>
                             Ze školy jsem odešel po třech semestrech. Cítil jsem, že více teorie mi neumožní být lidštějším, a tím pádem lepším terapeutem. Pokračoval jsem už jen ve výcviku, který jsem ukončil v roce 2019.
@@ -222,18 +222,18 @@
                     <h3 class="top cnt uppercase">Vzdělání</h3>
                     <ul class="education-list">
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA institut Praha</span>, komplexní výcvikový program v psychoterapii a poradenství zaměřeném na člověka
+                            2015–2019 <span class="bold">PCA institut Praha</span>, komplexní výcvikový program v psychoterapii a poradenství zaměřeném na člověka
                         </li>
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA institut Praha</span> výcvik v relaxačních technikách - Schultzův autogenní trénink
+                            2015–2019 <span class="bold">PCA institut Praha</span> výcvik v relaxačních technikách—Schultzův autogenní trénink
                         </li>
                         <li class="btm2">
-                            2014—2016 <span class="bold">Univerzita Vídeň,</span> psychologie (nedokončené)
+                            2014–2016 <span class="bold">Univerzita Vídeň,</span> psychologie (nedokončené)
                         </li>
                         <li class="btm2">
-                            2002—2009 <span class="bold">Technická univerzita Vídeň,</span> magisterské studium informatiky, dosažený titul Dipl.-Ing.
+                            2002–2009 <span class="bold">Technická univerzita Vídeň,</span> magisterské studium informatiky, dosažený titul Dipl.-Ing.
                         </li>
-                        <li class="btm2">1997—2002 <span class="bold">Obchodní akademie Neusiedl/See</span></li>
+                        <li class="btm2">1997–2002 <span class="bold">Obchodní akademie Neusiedl/See</span></li>
                     </ul>
                 </div>
             </div>

--- a/index-cs.html
+++ b/index-cs.html
@@ -89,9 +89,7 @@
                     </p>
                 </div>
             </div>
-            <div class="appt-intl">
-                <a href="#contact"><span>Objednejte si zkušební setkání</span></a>
-            </div>
+            <a href="#contact" class="appt-intl"><span>Objednejte si zkušební setkání</span></a>
         </section>
 
         <section class="individual-counselling">

--- a/index-cs.html
+++ b/index-cs.html
@@ -85,7 +85,7 @@
                         Někdy se stává, že sami neumíme vyřešit naše duševní obtíže. Tehdy není ostuda vyhledat pomoc. Ba právě naopak, včasná terapie může ušetřit člověka od zbytečného trápení.
                     </p>
                     <p>
-                        Terapie je cestou práce na sobě a umožňuje změnit sebe i svět—to, jak jej prožíváme. Tím se obnovuje sebedůvěra a radost ze života.
+                        Terapie je cestou práce na sobě a umožňuje změnit sebe i svět – to, jak jej prožíváme. Tím se obnovuje sebedůvěra a radost ze života.
                     </p>
                 </div>
             </div>
@@ -205,7 +205,7 @@
                             A nakonec to byla právě psychoterapie, která mi změnila pohled na život. Uvědomil jsem si při ní, že život je v pořádku, tak jak je. Krása tohoto uvědomění byla, že se jednalo o praktickou zkušenost, tedy zážitek a ne jen slova.
                         </p>
                         <p>
-                            Tehdy jsem našel své nové povolání. Dal jsem se na studium psychologie a na stejný výcvik, ve kterém jsem absolvoval terapii—PCA.
+                            Tehdy jsem našel své nové povolání. Dal jsem se na studium psychologie a na stejný výcvik, ve kterém jsem absolvoval terapii – PCA.
                         </p>
                         <p>
                             Ze školy jsem odešel po třech semestrech. Cítil jsem, že více teorie mi neumožní být lidštějším, a tím pádem lepším terapeutem. Pokračoval jsem už jen ve výcviku, který jsem ukončil v roce 2019.
@@ -222,18 +222,18 @@
                     <h3 class="top cnt uppercase">Vzdělání</h3>
                     <ul class="education-list">
                         <li class="btm2">
-                            2015–2019 <span class="bold">PCA institut Praha</span>, komplexní výcvikový program v psychoterapii a poradenství zaměřeném na člověka
+                            2015 – 2019 <span class="bold">PCA institut Praha</span>, komplexní výcvikový program v psychoterapii a poradenství zaměřeném na člověka
                         </li>
                         <li class="btm2">
-                            2015–2019 <span class="bold">PCA institut Praha</span> výcvik v relaxačních technikách—Schultzův autogenní trénink
+                            2015 – 2019 <span class="bold">PCA institut Praha</span> výcvik v relaxačních technikách—Schultzův autogenní trénink
                         </li>
                         <li class="btm2">
-                            2014–2016 <span class="bold">Univerzita Vídeň,</span> psychologie (nedokončené)
+                            2014 – 2016 <span class="bold">Univerzita Vídeň,</span> psychologie (nedokončené)
                         </li>
                         <li class="btm2">
-                            2002–2009 <span class="bold">Technická univerzita Vídeň,</span> magisterské studium informatiky, dosažený titul Dipl.-Ing.
+                            2002 – 2009 <span class="bold">Technická univerzita Vídeň,</span> magisterské studium informatiky, dosažený titul Dipl.-Ing.
                         </li>
-                        <li class="btm2">1997–2002 <span class="bold">Obchodní akademie Neusiedl/See</span></li>
+                        <li class="btm2">1997 – 2002 <span class="bold">Obchodní akademie Neusiedl/See</span></li>
                     </ul>
                 </div>
             </div>

--- a/index-de.html
+++ b/index-de.html
@@ -89,7 +89,7 @@
                     </p>
                 </div>
             </div>
-            <a href="#contact" class="appt-intl"><span>Erstgespräch vereinbaren</span></a>
+            <a href="#contact"><span>Erstgespräch vereinbaren</span></a>
         </section>
 
         <section class="individual-counselling">
@@ -221,19 +221,19 @@
                     <h3 class="cnt uppercase">Ausbildung</h3>
                     <ul class="education-list">
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA Institut,</span> Prag, Ausbildung im personzentrierten Ansatz in Beratung und Psychotherapie
+                            2015–2019 <span class="bold">PCA Institut,</span> Prag, Ausbildung im personzentrierten Ansatz in Beratung und Psychotherapie
                         </li>
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA Institut,</span> Prag, Ausbildung im autogenen Training nach Schultz
+                            2015–2019 <span class="bold">PCA Institut,</span> Prag, Ausbildung im autogenen Training nach Schultz
                         </li>
                         <li class="btm2">
-                            2014—2016 <span class="bold">Universität Wien,</span> Psychologie (exmatrikuliert)
+                            2014–2016 <span class="bold">Universität Wien,</span> Psychologie (exmatrikuliert)
                         </li>
                         <li class="btm2">
-                            2002—2009 <span class="bold">Technische Universität Wien,</span> Magisterstudium der Informatik. Abgeschlossen als Dipl.-Ing.
+                            2002–2009 <span class="bold">Technische Universität Wien,</span> Magisterstudium der Informatik. Abgeschlossen als Dipl.-Ing.
                         </li>
                         <li class="btm2">
-                            1997—2002 <span class="bold"> Handelsakademie Neusiedl/See</span> 
+                            1997–2002 <span class="bold"> Handelsakademie Neusiedl/See</span> 
                         </li>
                     </ul>
                 </div>

--- a/index-de.html
+++ b/index-de.html
@@ -89,10 +89,7 @@
                     </p>
                 </div>
             </div>
-
-            <div class="appt-intl">
-                <a href="#contact"><span>Erstgespräch vereinbaren</span></a>
-            </div>
+            <a href="#contact" class="appt-intl"><span>Erstgespräch vereinbaren</span></a>
         </section>
 
         <section class="individual-counselling">

--- a/index-de.html
+++ b/index-de.html
@@ -85,11 +85,11 @@
                         Im Leben kann es passieren, dass wir mit unseren seelischen Problemen nicht selbst klarkommen können. In so einem Fall ist es keine Blamage professionelle Hilfe in Anspruch zu nehmen. Ganz im Gegenteil, eine rechtzeitige Therapie kann sehr viel unnötiges Leiden ersparen.
                     </p>
                     <p>
-                        Die Therapie ist in dieser Hinsicht eine Möglichkeit an sich zu arbeiten, um sich selbst und auch die Welt — die Art und Weise, wie wir sie erleben — zu verändern. Damit wird das Selbstvertrauen und die Freude am Leben wieder aufgebaut.
+                        Die Therapie ist in dieser Hinsicht eine Möglichkeit an sich zu arbeiten, um sich selbst und auch die Welt – die Art und Weise, wie wir sie erleben – zu verändern. Damit wird das Selbstvertrauen und die Freude am Leben wieder aufgebaut.
                     </p>
                 </div>
             </div>
-            <a href="#contact"><span>Erstgespräch vereinbaren</span></a>
+            <a href="#contact" class="appt-intl"><span>Erstgespräch vereinbaren</span></a>
         </section>
 
         <section class="individual-counselling">
@@ -111,7 +111,7 @@
                 </div>
                 <div class="column70">
                     <p>
-                        Der personzentrierte Ansatz ist in der humanistischen Psychologie angesiedelt. Er ist auch unter dem Namen „Gesprächstherapie” bekannt. Dieser Ansatz wurde in den USA in den Fünfzigern des letzten Jahrhunderts von Carl C. Rogers entwickelt.
+                        Der personzentrierte Ansatz ist in der humanistischen Psychologie angesiedelt. Er ist auch unter dem Namen „Gesprächstherapie“ bekannt. Dieser Ansatz wurde in den USA in den Fünfzigern des letzten Jahrhunderts von Carl C. Rogers entwickelt.
                     </p>
                     <p>
                         Damals kam dieser Ansatz einer Revolution gleich, weil Rogers es ablehnte, die Rolle des Experten in Bezug auf das Leben der Klienten zu spielen. Stattdessen war sein Bestreben seine Klienten bedingungsfrei zu akzeptieren und zu verstehen. Daher kommt der Name „personzentriert“.
@@ -198,11 +198,11 @@
                         </p>
 
                         <p>
-                            Schließlich war es die Psychotherapie, dank der sich meine Einstellung zum Leben veränderte. Durch sie wurde mir bewusst, dass das Leben so in Ordnung ist, wie es ist.  Das Magische daran war, dass es eine Erfahrung - ein reales Erlebnis - war und nicht Information - leere Worte.
+                            Schließlich war es die Psychotherapie, dank der sich meine Einstellung zum Leben veränderte. Durch sie wurde mir bewusst, dass das Leben so in Ordnung ist, wie es ist.  Das Magische daran war, dass es eine Erfahrung – ein reales Erlebnis – war und nicht Information – leere Worte.
                         </p>
 
                         <p>
-                            Damit fand ich für mich eine neue Berufung. Ich inskribierte mich für Psychologie und begann gleichzeitig mit der Ausbildung in der Gesprächstherapie - in der Richtung, die mein Leben so stark beeinflusst hatte.
+                            Damit fand ich für mich eine neue Berufung. Ich inskribierte mich für Psychologie und begann gleichzeitig mit der Ausbildung in der Gesprächstherapie – in der Richtung, die mein Leben so stark beeinflusst hatte.
                         </p>
 
                         <p>
@@ -249,7 +249,7 @@
                     CZK für 50 Minuten.</span>
             </p>
             <p>
-                Die Therapiesitzung ist an ihrem Ende in voller Höhe bar zu bezahlen. Es handelt sich dabei um eine rein privat finanzierte Psychotherapie — ich arbeite nicht mit Krankenversicherungen zusammen. Für Sie hat es den Vorteil, dass Sie keine Diagnose von der Psychiatrie brauchen, um mich zu besuchen, dass die Wartezeiten normalerweise kürzer sind als bei Vertragspsychotherapeuten und, dass ich nicht verpflichtet bin Berichte über die Therapie an Ihre Krankenversicherung zu schicken.
+                Die Therapiesitzung ist an ihrem Ende in voller Höhe bar zu bezahlen. Es handelt sich dabei um eine rein privat finanzierte Psychotherapie – ich arbeite nicht mit Krankenversicherungen zusammen. Für Sie hat es den Vorteil, dass Sie keine Diagnose von der Psychiatrie brauchen, um mich zu besuchen, dass die Wartezeiten normalerweise kürzer sind als bei Vertragspsychotherapeuten und, dass ich nicht verpflichtet bin Berichte über die Therapie an Ihre Krankenversicherung zu schicken.
             </p>
             <p>
                 Die Therapiesitzung kann 24 Stunden vor dem Termin kostenfrei storniert werden, danach wird der volle Betrag fällig.

--- a/index-en.html
+++ b/index-en.html
@@ -230,16 +230,16 @@
                     <h3 class="cnt uppercase">Education</h3>
                     <ul class="education-list">
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA Institute,</span> Prague, Psychotherapy training in the person-centered approach
+                            2015–2019 <span class="bold">PCA Institute,</span> Prague, Psychotherapy training in the person-centered approach
                         </li>
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA Institute,</span> Prague, Autogenic Therapy training
+                            2015–2019 <span class="bold">PCA Institute,</span> Prague, Autogenic Therapy training
                         </li>
                         <li class="btm2">
-                            2014—2016 <span class="bold">University of Vienna,</span> Psychology (incomplete)
+                            2014–2016 <span class="bold">University of Vienna,</span> Psychology (incomplete)
                         </li>
                         <li class="btm2">
-                            2002—2009 <span class="bold">University of Technology,</span> Vienna, Master of Software Engineering &amp; Internet Computing
+                            2002–2009 <span class="bold">University of Technology,</span> Vienna, Master of Software Engineering &amp; Internet Computing
                         </li>
                     </ul>
                 </div>

--- a/index-en.html
+++ b/index-en.html
@@ -96,9 +96,7 @@
                     </p>
                 </div>
             </div>
-            <div class="appt-intl">
-                <a href="#contact"><span>Book initial appointment</span></a>
-            </div>
+            <a href="#contact" class="appt-intl"><span>Book initial appointment</span></a>
         </section>
 
         <section class="individual-counselling">

--- a/index-en.html
+++ b/index-en.html
@@ -205,7 +205,7 @@
                     <div class="column70">
                         <h3>Why I became a counsellor</h3>
                         <p>
-                            I experienced a hugely positive shift in my life thanks to counselling. Up until my early thirties I was quite successfully developing my IT career. Then I went through a life crisis because of a break up, which forced me to seek answers.
+                            I experienced a hugely positive shift in my life thanks to counselling. Up until my early thirties I was quite successfully developing my IT career. Then I went through a life crisis because of a break-up, which forced me to seek answers.
                         </p>
                         <p>
                             In the end it was counselling that transformed my perception of life. Thanks to it I realised that life is fine as it is. The beauty of this insight was that it was a real experience and not just mere words.
@@ -214,7 +214,7 @@
                             At this point I found my new calling. I started to study psychology and to train in the same kind of psychotherapy as I had benefited from: the person centered approach.
                         </p>
                         <p>
-                            I left university after three semesters. I felt that more theory would not make me a more empathic — and therefore better — as a counsellor. I then continued solely with my training, which I finished in 2019.
+                            I left university after three semesters. I felt that more theory would not make me a more empathic—and therefore better—counsellor. I then continued solely with my training, which I finished in 2019.
                         </p>
                         <p>
                             <h3 class="top-b">What I value about counselling</h3>

--- a/index-sk.html
+++ b/index-sk.html
@@ -85,7 +85,7 @@
                         Niekedy sa stáva, že si sami nevieme rady s našimi duševnými ťažkosťami. Vtedy nie je hanba vyhľadať pomoc. Ba práve naopak, včasná terapia môže ušetriť človeka od zbytočného trápenia.
                     </p>
                     <p>
-                        Terapia je cestou práce na sebe a umožňuje zmeniť seba i svet – to, ako ho prežívame. Tým sa obnovuje sebadôvera a radosť zo života.
+                        Terapia je cestou práce na sebe a umožňuje zmeniť seba i svet—to, ako ho prežívame. Tým sa obnovuje sebadôvera a radosť zo života.
                     </p>
                 </div>
             </div>
@@ -216,18 +216,18 @@
                     <h3 class="cnt uppercase">Vzdelanie</h3>
                     <ul class="education-list">
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA inštitút Praha</span>, komplexný výcvikový program v psychoterapii a poradenstve zameranom na človeka
+                            2015–2019 <span class="bold">PCA inštitút Praha</span>, komplexný výcvikový program v psychoterapii a poradenstve zameranom na človeka
                         </li>
                         <li class="btm2">
-                            2015—2019 <span class="bold">PCA inštitút Praha</span>, výcvik v relaxačných technikách - Schultzov autogénny tréning
+                            2015–2019 <span class="bold">PCA inštitút Praha</span>, výcvik v relaxačných technikách—Schultzov autogénny tréning
                         </li>
                         <li class="btm2">
-                            2014—2016 <span class="bold">Univerzita Viedeň,</span> psychológia (nedokončené)
+                            2014–2016 <span class="bold">Univerzita Viedeň,</span> psychológia (nedokončené)
                         </li>
                         <li class="btm2">
-                            2002—2009 <span class="bold">Technická univerzita Viedeň,</span> magisterské štúdium informatiky, dosiahnutý titul Dipl.-Ing.
+                            2002–2009 <span class="bold">Technická univerzita Viedeň,</span> magisterské štúdium informatiky, dosiahnutý titul Dipl.-Ing.
                         </li>
-                        <li class="btm2">1997—2002 <span class="bold">Obchodná akadémia Neusiedl/See</span></li>
+                        <li class="btm2">1997–2002 <span class="bold">Obchodná akadémia Neusiedl/See</span></li>
                     </ul>
                 </div>
             </div>

--- a/index-sk.html
+++ b/index-sk.html
@@ -85,7 +85,7 @@
                         Niekedy sa stáva, že si sami nevieme rady s našimi duševnými ťažkosťami. Vtedy nie je hanba vyhľadať pomoc. Ba práve naopak, včasná terapia môže ušetriť človeka od zbytočného trápenia.
                     </p>
                     <p>
-                        Terapia je cestou práce na sebe a umožňuje zmeniť seba i svet—to, ako ho prežívame. Tým sa obnovuje sebadôvera a radosť zo života.
+                        Terapia je cestou práce na sebe a umožňuje zmeniť seba i svet – to, ako ho prežívame. Tým sa obnovuje sebadôvera a radosť zo života.
                     </p>
                 </div>
             </div>
@@ -200,7 +200,7 @@
                         </p>
                         <p> A nakoniec bola to práve psychoterapia, ktorá mi zmenila pohľad na život. Uvedomil som si pri nej, že je v poriadku, tak ako je. Krása tohto uvedomenia bola, že sa jednalo o praktickú skúsenosť, teda zážitok a nie len slová.
                         </p>
-                        <p> Vtedy som našiel svoje nové povolanie. Dal som sa na štúdium psychológie a na ten istý výcvik, v ktorom som absolvoval terapiu—PCA.
+                        <p> Vtedy som našiel svoje nové povolanie. Dal som sa na štúdium psychológie a na ten istý výcvik, v ktorom som absolvoval terapiu – PCA.
                         </p>
                         <p> Z univerzity som odišiel po troch semestroch. Cítil som, že viac teórie mi neumožní byť ľudskejším a tým pádom lepším terapeutom. Pokračoval som už iba vo výcviku, ktorý som ukončil v roku 2019.
                         </p>
@@ -216,18 +216,18 @@
                     <h3 class="cnt uppercase">Vzdelanie</h3>
                     <ul class="education-list">
                         <li class="btm2">
-                            2015–2019 <span class="bold">PCA inštitút Praha</span>, komplexný výcvikový program v psychoterapii a poradenstve zameranom na človeka
+                            2015 – 2019 <span class="bold">PCA inštitút Praha</span>, komplexný výcvikový program v psychoterapii a poradenstve zameranom na človeka
                         </li>
                         <li class="btm2">
-                            2015–2019 <span class="bold">PCA inštitút Praha</span>, výcvik v relaxačných technikách—Schultzov autogénny tréning
+                            2015 – 2019 <span class="bold">PCA inštitút Praha</span>, výcvik v relaxačných technikách—Schultzov autogénny tréning
                         </li>
                         <li class="btm2">
-                            2014–2016 <span class="bold">Univerzita Viedeň,</span> psychológia (nedokončené)
+                            2014 – 2016 <span class="bold">Univerzita Viedeň,</span> psychológia (nedokončené)
                         </li>
                         <li class="btm2">
-                            2002–2009 <span class="bold">Technická univerzita Viedeň,</span> magisterské štúdium informatiky, dosiahnutý titul Dipl.-Ing.
+                            2002 – 2009 <span class="bold">Technická univerzita Viedeň,</span> magisterské štúdium informatiky, dosiahnutý titul Dipl.-Ing.
                         </li>
-                        <li class="btm2">1997–2002 <span class="bold">Obchodná akadémia Neusiedl/See</span></li>
+                        <li class="btm2">1997 – 2002 <span class="bold">Obchodná akadémia Neusiedl/See</span></li>
                     </ul>
                 </div>
             </div>

--- a/index-sk.html
+++ b/index-sk.html
@@ -89,9 +89,7 @@
                     </p>
                 </div>
             </div>
-            <div class="appt-intl">
-                <a href="#contact"><span>Objednajte si skúšobné stretnutie</span></a>
-            </div>
+            <a href="#contact" class="appt-intl"><span>Objednajte si skúšobné stretnutie</span></a>
         </section>
 
         <section class="individual-counselling">

--- a/styles.css
+++ b/styles.css
@@ -387,7 +387,7 @@ ul {
     padding-top: 2rem;
 }
 
-@media (min-width: 770px) {
+@media (min-width: 770px){
     .portrait-mobile {
         display: none;
     }
@@ -443,7 +443,7 @@ issues-list {
 .contact-card {
     text-align: center;
     width: 280px;
-    height: auto;
+    height: 140px;
     flex-grow: 0.3;
     flex-shrink: 0;
     margin: 3rem auto;
@@ -451,6 +451,16 @@ issues-list {
     font-size: 1.7rem;
     background-color: hsl(0, 0%, 100%);;
     box-shadow: 0 1px 0 #db4a0d7d, 0 4px 6px #db4a0d7a;
+}
+@media (min-width:699.99px){
+    .contact-card{
+        height: 220px;;
+    }
+}
+@media (min-width:699.99px)and (max-width: 1200px) {
+    .contact-card{
+        padding-top: 4rem;;
+    }
 }
 
 .contact-card-email::before {

--- a/styles.css
+++ b/styles.css
@@ -146,11 +146,13 @@ ul {
 /* Mobile Navigation */
 .accordion {
     width: 50%;
+    margin-top: 0.2rem;
     border: none;
     outline: none;
     border: 1px solid hsl(0, 0%, 100%);
     border-radius: 3px;
     padding: 1rem;
+    font-weight: bold;
     background-color: hsl(16, 100%, 66%);
 }
 
@@ -190,7 +192,7 @@ ul {
     margin-left: auto;
     margin-right: auto;
     border-bottom: 1px solid papayawhip;
-    padding: 2rem 3rem;
+    padding: 2rem;
     font-size: 1.5rem;
 }
 .menu-item :last-child {

--- a/styles.css
+++ b/styles.css
@@ -24,10 +24,41 @@ body {
     letter-spacing: 0.0625em;
 }
 
+.container {
+    max-width: 1200px;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+}
+
 /* General text styles */
 h1 {
     margin: 0;
 }
+
+h2 {
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    margin-block-start: 0px;
+    margin-block-end: 0px;
+    font-size: 2rem;
+}
+
+h3 {
+    margin-top: 1rem;
+    margin-block-start: 0px;
+    margin-block-end: 0.5rem;
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+p {
+    margin-top: 0.4rem;
+    font-size: 1.5rem;
+    line-height: 1.5;
+}
+
 a {
     padding: 0;
     background-color: none;
@@ -35,7 +66,6 @@ a {
     color: hsl(0, 0%, 0%);
     border: none;
 }
-
 a:hover {
     color: hsl(0, 0%, 100%);
     background-color: hsl(300, 47%, 75%);
@@ -363,45 +393,6 @@ ul {
     }
 }
 
-.smaller-text {
-    padding-right: 2rem;
-    font-weight: 300;
-}
-
-.text-left {
-    font-size: 3rem;
-}
-
-h2 {
-    margin-top: 1rem;
-    margin-bottom: 0.5rem;
-    margin-block-start: 0px;
-    margin-block-end: 0px;
-    font-size: 2rem;
-}
-
-h3 {
-    margin-top: 1rem;
-    margin-block-start: 0px;
-    margin-block-end: 0.5rem;
-    font-size: 2rem;
-    font-weight: 700;
-}
-
-p {
-    margin-top: 0.4rem;
-    font-size: 1.5rem;
-    line-height: 1.5;
-}
-
-.container {
-    max-width: 1200px;
-    padding-right: 15px;
-    padding-left: 15px;
-    margin-right: auto;
-    margin-left: auto;
-}
-
 /*Header*/
 
 .contact {
@@ -473,7 +464,6 @@ issues-list {
     font-family: "fontawesome";
     padding-right: 0.5rem;
 }
-
 
 .premises {
     color: hsl(300, 100%, 25%);
@@ -578,4 +568,13 @@ issues-list {
 .hover-dark:hover {
     color: hsl(300, 100%, 25%);
     font-weight: 700;
+}
+
+.smaller-text {
+    padding-right: 2rem;
+    font-weight: 300;
+}
+
+.text-left {
+    font-size: 3rem;
 }

--- a/styles.css
+++ b/styles.css
@@ -309,28 +309,29 @@ ul {
 }
 
 .appt-intl {
-    display: none;
+    display: block;
+    margin: 3rem auto;
+    text-align: center;
+    border-radius: 12.5px;
+    padding: 1.5rem 1rem;
+/*     border: 1px solid hsl(16, 100%, 66%); */
+    max-width: 50%;
+    font-size: 1.7rem;
+    font-weight: bold;
+/*     background: linear-gradient(126.6deg, hsl(16, 100%, 66%), white); */
+    background-color: hsl(16, 100%, 66%);
+    box-shadow: 0 1px 0 #db4a0d7d, 0 4px 6px #db4a0d7a;
 }
-@media (max-width: 760px) {
+@media (min-width: 760px) {
     .appt-intl {
-        display: block;
-        text-align: center;
-        margin: 3rem auto;
-        border: 1px solid hsl(16, 100%, 66%);
-        border-radius: 12.5px;
-        padding: 1.5rem 1rem;
-        max-width: 50%;
-        font-size: 1.7rem;
-        background: linear-gradient(126.6deg, hsl(16, 100%, 66%), white);
-        background-color: hsl(0, 0%, 100%);
-        box-shadow: 0 1px 0 #db4a0d7d, 0 4px 6px #db4a0d7a;
+        display: none;
     }
 }
 
-@media (max-width: 760px) {
-    .appt-intl :hover {
+
+.appt-intl :hover {
+    background-color: hsl(300, 47%, 75%);
         color: hsl(300, 100%, 25%);
-    }
 }
 
 .portrait {

--- a/styles.css
+++ b/styles.css
@@ -540,15 +540,7 @@ issues-list {
 .btm2 {
     list-style: none;
     margin-bottom: 0.5rem;
-}
-.btm2::before {
-    content: "";
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    margin-right: 5px;
-    vertical-align: middle;
-    background-color: hsl(16, 100%, 66%);
+    padding-top: 1.5rem;
 }
 
 .light {

--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,7 @@ ul {
 /* Mobile Navigation */
 .accordion {
     width: 50%;
-    margin-top: 0.2rem;
+    margin-top: 0.3rem;
     border: none;
     outline: none;
     border: 1px solid hsl(0, 0%, 100%);


### PR DESCRIPTION
The div tag from the button has been removed and the remaining link can now be styled with classes to achieve change of background colour when hovered over.
The gradient nevertheless had to go as the the pseudo-class :hover did not work on it.

The **menu button** now appears centred because the menu items have decreased padding and so they fit narrower viewports.

I attempted to apply **the correct language specific rules for the use of dashes and hyphens**. The rules vary depending on the language. The **hyphen**, the shortest length, is universally used to connect: čierno-biely, break-in. The longer length or the **en dash** is universally used for span or range as in dates. In German and in English it has NO space before and after, but in Slovak and Czech it needs a space before and after. The longest one, the **em-dash**, is most frequently used in English and in some cases in Slovak: for instance to show dialogue in text. It can appear with or without space, American newspapers apparently prefer the version with them: https://www.thepunctuationguide.com/em-dash.html
https://www.typolexikon.de/halbgeviertstrich/
http://www.ad1.sk/zaklady-typografie-a-typograficke-pravidla/